### PR TITLE
Remove distribute dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     install_requires=[
         'six',
         'django',
-        'distribute',
     ],
     setup_requires = [
         'versiontools >= 1.8',


### PR DESCRIPTION
Because is now merged with setuptools.
