### PR TITLE
Fixed typographical error, changed aplication to application in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Using a custom sampledata command
 
 You can create a command to fill your models manullay to take more control.
 
-If you have some aplications to populate, you can split your sample data
+If you have some applications to populate, you can split your sample data
 generation on one command per app, or add only one command in one app thats
 generate everything.
 


### PR DESCRIPTION
@kaleidos, I've corrected a typographical error in the documentation of the [django-sampledatahelper](https://github.com/kaleidos/django-sampledatahelper) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.